### PR TITLE
new/maniphttp: added ExtractTransport helper

### DIFF
--- a/maniphttp/helpers.go
+++ b/maniphttp/helpers.go
@@ -132,6 +132,18 @@ func DirectSend(manipulator manipulate.Manipulator, mctx manipulate.Context, end
 	return m.send(mctx, method, url, bytes.NewReader(body), nil, sp)
 }
 
+// ExtractTransport returns the transport used by the given manipulator.
+// This is an advanced feature and the returned transport should not be modified
+func ExtractTransport(manipulator manipulate.Manipulator) *http.Transport {
+
+	m, ok := manipulator.(*httpManipulator)
+	if !ok {
+		panic("You can only pass a HTTP Manipulator to ExtractTransport")
+	}
+
+	return m.transport
+}
+
 // BatchCreate is an experimental feature that may eventually be incorporated in the standard interface.
 //
 // But for now it is not recommended to use it unless you know exactly how

--- a/maniphttp/helpers.go
+++ b/maniphttp/helpers.go
@@ -133,7 +133,7 @@ func DirectSend(manipulator manipulate.Manipulator, mctx manipulate.Context, end
 }
 
 // ExtractTransport returns the transport used by the given manipulator.
-// This is an advanced feature and the returned transport should not be modified
+// This is an advanced feature and the returned transport should not be modified.
 func ExtractTransport(manipulator manipulate.Manipulator) *http.Transport {
 
 	m, ok := manipulator.(*httpManipulator)
@@ -142,6 +142,18 @@ func ExtractTransport(manipulator manipulate.Manipulator) *http.Transport {
 	}
 
 	return m.transport
+}
+
+// ExtractClient returns the http.Client used by the given manipulator.
+// This is an advanced feature and the returned client should not be modified.
+func ExtractClient(manipulator manipulate.Manipulator) *http.Client {
+
+	m, ok := manipulator.(*httpManipulator)
+	if !ok {
+		panic("You can only pass a HTTP Manipulator to ExtractClient")
+	}
+
+	return m.client
 }
 
 // BatchCreate is an experimental feature that may eventually be incorporated in the standard interface.

--- a/maniphttp/helpers_test.go
+++ b/maniphttp/helpers_test.go
@@ -512,3 +512,35 @@ func TestExtractTransport(t *testing.T) {
 		})
 	})
 }
+
+func TestExtractClient(t *testing.T) {
+
+	Convey("Given I have an httpmanipulator with namespace", t, func() {
+
+		client := &http.Client{}
+		m := &httpManipulator{
+			client: client,
+		}
+
+		Convey("When I call ExtractClient", func() {
+
+			t := ExtractClient(m)
+
+			Convey("Then I should get the correct client", func() {
+				So(t, ShouldEqual, client)
+			})
+		})
+	})
+
+	Convey("Given I have a non http manipulator", t, func() {
+
+		m := maniptest.NewTestManipulator()
+
+		Convey("When I call ExtractClient", func() {
+
+			Convey("Then it should panic", func() {
+				So(func() { ExtractClient(m) }, ShouldPanicWith, "You can only pass a HTTP Manipulator to ExtractClient")
+			})
+		})
+	})
+}

--- a/maniphttp/helpers_test.go
+++ b/maniphttp/helpers_test.go
@@ -480,3 +480,35 @@ func TestManiphttp_BatchCreate(t *testing.T) {
 	})
 
 }
+
+func TestExtractTransport(t *testing.T) {
+
+	Convey("Given I have an httpmanipulator with namespace", t, func() {
+
+		transport := &http.Transport{}
+		m := &httpManipulator{
+			transport: transport,
+		}
+
+		Convey("When I call ExtractTransport", func() {
+
+			t := ExtractTransport(m)
+
+			Convey("Then I should get the correct transport", func() {
+				So(t, ShouldEqual, transport)
+			})
+		})
+	})
+
+	Convey("Given I have a non http manipulator", t, func() {
+
+		m := maniptest.NewTestManipulator()
+
+		Convey("When I call ExtractTransport", func() {
+
+			Convey("Then it should panic", func() {
+				So(func() { ExtractTransport(m) }, ShouldPanicWith, "You can only pass a HTTP Manipulator to ExtractTransport")
+			})
+		})
+	})
+}


### PR DESCRIPTION
This patch adds the ExtractTransport helper to retrieve the http.Transport used by the given HTTP manipulator.