### PR TITLE
new/manipmongo: support for ContextOptionNamespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint:
 		--enable=errcheck \
 		--enable=goimports \
 		--enable=ineffassign \
-		--enable=golint \
+		--enable=revive \
 		--enable=unused \
 		--enable=structcheck \
 		--enable=staticcheck \

--- a/filter_test.go
+++ b/filter_test.go
@@ -12,32 +12,204 @@
 package manipulate
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
-	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/elemental"
 )
 
-func TestNewFilter(t *testing.T) {
+func TestNewNamespaceFilter(t *testing.T) {
+	type args struct {
+		namespace string
+		recursive bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want *elemental.Filter
+	}{
+		{
+			"non recursive non root",
+			args{
+				"/a/b",
+				false,
+			},
+			elemental.NewFilterComposer().WithKey("namespace").Equals("/a/b").Done(),
+		},
+		{
+			"recursive non root",
+			args{
+				"/a/b",
+				true,
+			},
+			elemental.NewFilterComposer().Or(
+				elemental.NewFilterComposer().WithKey("namespace").Equals("/a/b").Done(),
+				elemental.NewFilterComposer().WithKey("namespace").Matches("^/a/b/").Done(),
+			).Done(),
+		},
+		{
+			"non recursive root",
+			args{
+				"/",
+				false,
+			},
+			elemental.NewFilterComposer().WithKey("namespace").Equals("/").Done(),
+		},
+		{
+			"non recursive empty",
+			args{
+				"",
+				false,
+			},
+			elemental.NewFilterComposer().WithKey("namespace").Equals("/").Done(),
+		},
+		{
+			"recursive empty",
+			args{
+				"",
+				true,
+			},
+			elemental.NewFilterComposer().WithKey("namespace").Matches("^/").Done(),
+		},
+	}
 
-	Convey("Calling NewFilter should work", t, func() {
-		f := NewFilter()
-		So(f, ShouldHaveSameTypeAs, elemental.NewFilter())
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewNamespaceFilter(tt.args.namespace, tt.args.recursive); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NamespaceFilter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
-	Convey("Calling NewFilterComposer should work", t, func() {
-		f := NewFilterComposer()
-		So(f, ShouldHaveSameTypeAs, elemental.NewFilterComposer())
-	})
+func TestNewFiltersFromQueryParameters(t *testing.T) {
+	type args struct {
+		parameters elemental.Parameters
+	}
+	tests := []struct {
+		name string
+		args func(t *testing.T) args
 
-	Convey("Calling NewFilterFromString should work", t, func() {
-		f, _ := NewFilterFromString("a == a")
-		ef, _ := elemental.NewFilterFromString("a == a")
-		So(f, ShouldHaveSameTypeAs, ef)
-	})
+		want1      []*elemental.Filter
+		wantErr    bool
+		inspectErr func(err error, t *testing.T) //use for more precise error evaluation after test
+	}{
+		{
+			"nil parameters",
+			func(t *testing.T) args {
+				return args{
+					parameters: nil,
+				}
+			},
+			[]*elemental.Filter{},
+			false,
+			nil,
+		},
+		{
+			"empty parameters",
+			func(t *testing.T) args {
+				return args{
+					parameters: elemental.Parameters{},
+				}
+			},
+			[]*elemental.Filter{},
+			false,
+			nil,
+		},
+		{
+			"unrelated parameters",
+			func(t *testing.T) args {
+				return args{
+					parameters: elemental.Parameters{
+						"not-q": elemental.NewParameter(elemental.ParameterTypeDuration, 10*time.Second),
+					},
+				}
+			},
+			[]*elemental.Filter{},
+			false,
+			nil,
+		},
+		{
+			"invalid parameter type",
+			func(t *testing.T) args {
+				return args{
+					parameters: elemental.Parameters{
+						"q": elemental.NewParameter(elemental.ParameterTypeDuration, 10*time.Second),
+					},
+				}
+			},
+			[]*elemental.Filter{},
+			false,
+			nil,
+		},
+		{
+			"simple valid parameters",
+			func(t *testing.T) args {
+				return args{
+					parameters: elemental.Parameters{
+						"q": elemental.NewParameter(elemental.ParameterTypeString, "prop == value"),
+					},
+				}
+			},
+			[]*elemental.Filter{
+				elemental.NewFilterComposer().WithKey("prop").Equals("value").Done(),
+			},
+			false,
+			nil,
+		},
+		{
+			"simple valid multiple parameter",
+			func(t *testing.T) args {
+				return args{
+					parameters: elemental.Parameters{
+						"q": elemental.NewParameter(elemental.ParameterTypeString, "prop == value", "prop2 == value2"),
+					},
+				}
+			},
+			[]*elemental.Filter{
+				elemental.NewFilterComposer().WithKey("prop").Equals("value").Done(),
+				elemental.NewFilterComposer().WithKey("prop2").Equals("value2").Done(),
+			},
+			false,
+			nil,
+		},
+		{
+			"invalid filter in parameters",
+			func(t *testing.T) args {
+				return args{
+					parameters: elemental.Parameters{
+						"q": elemental.NewParameter(elemental.ParameterTypeString, "prop = oh no! this is not a filter"),
+					},
+				}
+			},
+			nil,
+			true,
+			func(err error, t *testing.T) {
+				if err.Error() != "unable to parse filter in query parameter: invalid operator. found = instead of (==, !=, <, <=, >, >=, contains, in, matches, exists)" {
+					t.Fail()
+				}
+			},
+		},
+	}
 
-	Convey("Calling NewFilterParser should work", t, func() {
-		f := NewFilterParser("a == a")
-		So(f, ShouldHaveSameTypeAs, elemental.NewFilterParser("a == a"))
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tArgs := tt.args(t)
+
+			got1, err := NewFiltersFromQueryParameters(tArgs.parameters)
+
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("NewFiltersFromQueryParameters got1 = %v, want1: %v", got1, tt.want1)
+			}
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewFiltersFromQueryParameters error = %v, wantErr: %t", err, tt.wantErr)
+			}
+
+			if tt.inspectErr != nil {
+				tt.inspectErr(err, t)
+			}
+		})
+	}
 }

--- a/maniphttp/internal/syscall/syscall_linux.go
+++ b/maniphttp/internal/syscall/syscall_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package syscall

--- a/maniphttp/internal/syscall/syscall_nonlinux.go
+++ b/maniphttp/internal/syscall/syscall_nonlinux.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package syscall

--- a/maniphttp/manipulator_unix_test.go
+++ b/maniphttp/manipulator_unix_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 // Copyright 2019 Aporeto Inc.


### PR DESCRIPTION
This patch adds necessary functions that are now used by manipmongo to (finally) understand ContextOptionNamespace

Also remove 2y old deprecated type alias manipulate.Filter -> elemental.Filter