### PR TITLE
new: add SelfTokenManager interface

### DIFF
--- a/maniphttp/manipulator.go
+++ b/maniphttp/manipulator.go
@@ -130,6 +130,10 @@ func New(ctx context.Context, url string, options ...Option) (manipulate.Manipul
 
 	if m.tokenManager != nil {
 
+		if s, ok := m.tokenManager.(manipulate.SelfTokenManager); ok {
+			s.SetManipulator(m)
+		}
+
 		ictx, cancel := context.WithTimeout(m.ctx, 30*time.Second)
 		defer cancel()
 

--- a/manipulate.go
+++ b/manipulate.go
@@ -119,3 +119,14 @@ type TokenManager interface {
 	// given channel.
 	Run(ctx context.Context, tokenCh chan string)
 }
+
+// A SelfTokenManager is a TokenManager that can use the manipulator it is used
+// with to retrieve a token. Manipulator will call this function passing
+// itself before using any other method of the interface.
+type SelfTokenManager interface {
+
+	// SetManipulator will be called to inject the manipulator.
+	SetManipulator(Manipulator)
+
+	TokenManager
+}


### PR DESCRIPTION
A SelfTokenManager is a TokenManager with SetManipulator as
an additional method. This methiod will be called before the
token manager is used.

This can be useful when you can use the current manipulator
to renew tokens.
