### PR TITLE
fixed/manipmongo: error handling for setMaxTime

### DIFF
--- a/manipmongo/manipulator.go
+++ b/manipmongo/manipulator.go
@@ -214,9 +214,9 @@ func (m *mongoManipulator) RetrieveMany(mctx manipulate.Context, dest elemental.
 	}
 
 	// Query timing limiting
-	q = q.SetMaxTime(defaultGlobalContextTimeout)
-	if d, ok := mctx.Context().Deadline(); ok {
-		q = q.SetMaxTime(time.Until(d))
+	var err error
+	if q, err = setMaxTime(mctx.Context(), q); err != nil {
+		return err
 	}
 
 	if _, err := RunQuery(
@@ -345,9 +345,9 @@ func (m *mongoManipulator) Retrieve(mctx manipulate.Context, object elemental.Id
 		q = q.Select(sels)
 	}
 
-	q = q.SetMaxTime(defaultGlobalContextTimeout)
-	if d, ok := mctx.Context().Deadline(); ok {
-		q = q.SetMaxTime(time.Until(d))
+	var err error
+	if q, err = setMaxTime(mctx.Context(), q); err != nil {
+		return err
 	}
 
 	if _, err := RunQuery(
@@ -887,10 +887,11 @@ func (m *mongoManipulator) Count(mctx manipulate.Context, identity elemental.Ide
 	sp := tracing.StartTrace(mctx, fmt.Sprintf("manipmongo.count.%s", identity.Category))
 	defer sp.Finish()
 
-	q := c.Find(filter).SetMaxTime(defaultGlobalContextTimeout)
+	q := c.Find(filter)
 
-	if d, ok := mctx.Context().Deadline(); ok {
-		q = q.SetMaxTime(time.Until(d))
+	var err error
+	if q, err = setMaxTime(mctx.Context(), q); err != nil {
+		return 0, err
 	}
 
 	out, err := RunQuery(

--- a/manipmongo/utils.go
+++ b/manipmongo/utils.go
@@ -12,11 +12,13 @@
 package manipmongo
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
@@ -385,4 +387,19 @@ func explain(query *mgo.Query, operation elemental.Operation, identity elemental
 	fmt.Println("")
 
 	return nil
+}
+
+func setMaxTime(ctx context.Context, q *mgo.Query) (*mgo.Query, error) {
+
+	d, ok := ctx.Deadline()
+	if !ok {
+		return q.SetMaxTime(defaultGlobalContextTimeout), nil
+	}
+
+	mx := time.Until(d)
+	if err := ctx.Err(); err != nil {
+		return nil, manipulate.ErrCannotBuildQuery{Err: err}
+	}
+
+	return q.SetMaxTime(mx), nil
 }

--- a/manipmongo/utils_test.go
+++ b/manipmongo/utils_test.go
@@ -12,16 +12,19 @@
 package manipmongo
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/globalsign/mgo"
 	"github.com/globalsign/mgo/bson"
 	"github.com/golang/mock/gomock"
+	. "github.com/smartystreets/goconvey/convey"
 	"go.aporeto.io/elemental"
 	"go.aporeto.io/manipulate"
 	"go.aporeto.io/manipulate/manipmongo/internal"
@@ -1108,4 +1111,51 @@ func Test_explainIfNeeded(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetMaxTime(t *testing.T) {
+
+	Convey("Calling setMaxTime with a context with no deadline should work", t, func() {
+		q := &mgo.Query{}
+		q, err := setMaxTime(context.Background(), q)
+		So(err, ShouldBeNil)
+		qr := (&mgo.Query{}).SetMaxTime(defaultGlobalContextTimeout)
+		So(q, ShouldResemble, qr)
+	})
+
+	Convey("Calling setMaxTime with a context with valid deadline should work", t, func() {
+		q := &mgo.Query{}
+		deadline := time.Now().Add(3 * time.Second)
+		ctx, cancel := context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+
+		q, err := setMaxTime(ctx, q)
+		So(err, ShouldBeNil)
+		qr := (&mgo.Query{}).SetMaxTime(time.Until(deadline))
+		So(q, ShouldResemble, qr)
+	})
+
+	Convey("Calling setMaxTime with a context with expired deadline should not work", t, func() {
+		q := &mgo.Query{}
+		deadline := time.Now().Add(-3 * time.Second)
+		ctx, cancel := context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+
+		q, err := setMaxTime(ctx, q)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual, "Unable to build query: context deadline exceeded")
+		So(q, ShouldBeNil)
+	})
+
+	Convey("Calling setMaxTime with a canceled context should not work", t, func() {
+		q := &mgo.Query{}
+		deadline := time.Now().Add(3 * time.Second)
+		ctx, cancel := context.WithDeadline(context.Background(), deadline)
+		cancel()
+
+		q, err := setMaxTime(ctx, q)
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldEqual, "Unable to build query: context canceled")
+		So(q, ShouldBeNil)
+	})
 }


### PR DESCRIPTION
This patch adds a better error management when manipmongo calls q.SetMaxTime, by verifying that the given context is not in error. If so, returns a manipulate.ErrCannotBuildQuery wrapping the error.

